### PR TITLE
fix license missing in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "fontsensei",
   "version": "0.1.0",
+  "license": "MIT",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Adds the MIT license already in [LICENSE.md](../blob/main/LICENSE.md) to Package.json

Mostly so it complains less when running the development server