### PR TITLE
fix i18n of "Feedback"

### DIFF
--- a/src/browser/fontPicker/landingComponents.tsx
+++ b/src/browser/fontPicker/landingComponents.tsx
@@ -5,13 +5,13 @@ import {FontPickerPageContextOpts} from "@fontsensei/components/fontPickerCommon
 import useEmbedStore from "./embed/useEmbedStore";
 import EmbedModal from "./embed/EmbedModal";
 import {MdOutlineFeedback} from "react-icons/md";
-import {useI18n} from "@fontsensei/locales";
+import {useScopedI18n} from "@fontsensei/locales";
 
 const GITHUB_LINK = "https://github.com/mrbirddev/fontsensei";
-export const getExtraMenuItems = (t: ReturnType<typeof useI18n>) => [
+export const getExtraMenuItems = () => [
   {
     icon: <MdOutlineFeedback />,
-    label: t("landingMsg.Feedback"),
+    label: useScopedI18n("landingMsg")("Feedback"),
     href: GITHUB_LINK + "/issues/new",
     target: "_blank",
   },

--- a/src/pages/embed/index.tsx
+++ b/src/pages/embed/index.tsx
@@ -3,15 +3,13 @@ import {NavbarContext} from "../../browser/fontPicker/FontPickerPage";
 import React from "react";
 import {FontPickerPageContext} from "@fontsensei/components/fontPickerCommon";
 import {getExtraMenuItems} from "../../browser/fontPicker/landingComponents";
-import {useI18n} from "@nextutils/locales";
 import EmbeddedToolbar from "../../shared/embed/EmbeddedToolbar";
 
 export {getServerSideProps} from "../../browser/fontPicker/FontPickerPage";
 export default (props: Parameters<typeof FontPickerPage>[0]) => {
-  const t = useI18n();
   return <NavbarContext.Provider value={{
     shouldHide: true,
-    extraMenuItems: getExtraMenuItems(t),
+    extraMenuItems: getExtraMenuItems(),
     noSwitchLocaleHint: true,
   }}>
     <FontPickerPageContext.Provider value={{

--- a/src/pages/embed/tag/[[...slugList]].tsx
+++ b/src/pages/embed/tag/[[...slugList]].tsx
@@ -3,15 +3,13 @@ import {NavbarContext} from "../../../browser/fontPicker/FontPickerPage";
 import React from "react";
 import {FontPickerPageContext} from "@fontsensei/components/fontPickerCommon";
 import {getExtraMenuItems} from "../../../browser/fontPicker/landingComponents";
-import {useI18n} from "@nextutils/locales";
 import EmbeddedToolbar from "../../../shared/embed/EmbeddedToolbar";
 
 export {getServerSideProps} from "../../../browser/fontPicker/FontPickerPage";
 export default (props: Parameters<typeof FontPickerPage>[0]) => {
-  const t = useI18n();
   return <NavbarContext.Provider value={{
     shouldHide: true,
-    extraMenuItems: getExtraMenuItems(t),
+    extraMenuItems: getExtraMenuItems(),
     noSwitchLocaleHint: true,
   }}>
     <FontPickerPageContext.Provider value={{

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -3,13 +3,11 @@ import {NavbarContext} from "../browser/fontPicker/FontPickerPage";
 import React from "react";
 import {FontPickerPageContext} from "@fontsensei/components/fontPickerCommon";
 import {getExtraMenuItems, Toolbar} from "../browser/fontPicker/landingComponents";
-import {useI18n} from "@nextutils/locales";
 
 export {getServerSideProps} from "../browser/fontPicker/FontPickerPage";
 export default (props: Parameters<typeof FontPickerPage>[0]) => {
-  const t = useI18n();
   return <NavbarContext.Provider value={{
-    extraMenuItems: getExtraMenuItems(t),
+    extraMenuItems: getExtraMenuItems(),
   }}>
     <FontPickerPageContext.Provider value={{
       Toolbar: Toolbar,

--- a/src/pages/tag/[[...slugList]].tsx
+++ b/src/pages/tag/[[...slugList]].tsx
@@ -3,13 +3,11 @@ import {NavbarContext} from "../../browser/fontPicker/FontPickerPage";
 import React from "react";
 import {FontPickerPageContext} from "@fontsensei/components/fontPickerCommon";
 import {getExtraMenuItems, Toolbar} from "../../browser/fontPicker/landingComponents";
-import {useI18n} from "@nextutils/locales";
 
 export {getServerSideProps} from "../../browser/fontPicker/FontPickerPage";
 export default (props: Parameters<typeof FontPickerPage>[0]) => {
-  const t = useI18n();
   return <NavbarContext.Provider value={{
-    extraMenuItems: getExtraMenuItems(t),
+    extraMenuItems: getExtraMenuItems(),
   }}>
     <FontPickerPageContext.Provider value={{
       Toolbar: Toolbar,


### PR DESCRIPTION
Fixes the text in the sidebar not displaying as the correct landingMsg text.

For some reason the useI18n syntax of `locale.string` doesn't seem to work? I switched it over to just using the `useScopedI18n` and refactored out the repeated function passing as it was always the same function of `useI18n` in all use cases.

## Before

![image](https://github.com/user-attachments/assets/50808ddf-0993-4619-8a25-8fdccc51327e)

zh-cn:

![image](https://github.com/user-attachments/assets/38b096db-a025-4c67-8bcc-4b303a6a9d5b)

## After

![image](https://github.com/user-attachments/assets/abc7aed8-7206-4889-a2ff-1fe792d6f357)

zh-cn:

![image](https://github.com/user-attachments/assets/97b75ac6-2512-4583-b927-17a97fa406e2)