### PR TITLE
fix pretty-locales command

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "postinstall": "husky",
     "lint": "next lint --quiet",
     "nibble": "eslint-nibble src --config ./.eslintrc.cjs --ext .jsx,.js,.tsx,.ts",
-    "pretty-locales": "npx prettier --write --trailing-comma none --bracket-spacing false --print-width 100000 --tab-width 2 --quote-props preserve \"src/@nextutils/locales/**/*.ts\"",
+    "pretty-locales": "npx prettier --write --trailing-comma none --bracket-spacing false --print-width 100000 --tab-width 2 --quote-props preserve \"src/{@fontsensei,@nextutils}/locales/**/*.ts\"",
     "typecheck": "tsc --noEmit",
     "start": "next start"
   },

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "postinstall": "husky",
     "lint": "next lint --quiet",
     "nibble": "eslint-nibble src --config ./.eslintrc.cjs --ext .jsx,.js,.tsx,.ts",
-    "pretty-locales": "npx prettier --write --trailing-comma none --bracket-spacing false --print-width 100000 --tab-width 2 --quote-props preserve \"src/locales/**/*.ts\"",
+    "pretty-locales": "npx prettier --write --trailing-comma none --bracket-spacing false --print-width 100000 --tab-width 2 --quote-props preserve \"src/@nextutils/locales/**/*.ts\"",
     "typecheck": "tsc --noEmit",
     "start": "next start"
   },


### PR DESCRIPTION
Fixes the pretty-locales command to use the correct directory.

After this is merged, make sure you run it yourself as I didn't want to clutter this commit with my local run of it.