### PR TITLE
add prettier-code script

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "lint": "next lint --quiet",
     "nibble": "eslint-nibble src --config ./.eslintrc.cjs --ext .jsx,.js,.tsx,.ts",
     "pretty-locales": "npx prettier --write --trailing-comma none --bracket-spacing false --print-width 100000 --tab-width 2 --quote-props preserve \"src/locales/**/*.ts\"",
+    "pretty-code": "npx prettier --write \"src/**/*.{ts,tsx}\" \"!src/{@fontsensei,@nextutils}/locales/**/*.ts\"",
     "typecheck": "tsc --noEmit",
     "start": "next start"
   },


### PR DESCRIPTION
Adds `prettier-code` as a script that formats everything in the project that is not a locale. This uses the corrected locales folder location as in #10 and can be merged along side it.